### PR TITLE
release: publish 5tratSmack 0.11.10 to MAIN

### DIFF
--- a/scripts/finalize-5tratsmack-0.11.10-main.sh
+++ b/scripts/finalize-5tratsmack-0.11.10-main.sh
@@ -48,4 +48,7 @@ grep -Fx "      APP_IMAGE: ghcr.io/willitmod/5tratsmack-app:0.11.10@${app_digest
 grep -Fx "      APP_REVISION: ${source_revision}" "$compose" >/dev/null
 grep -Fx "      BCH2_NODE_IMAGE: ghcr.io/willitmod/5tratsmack-core:0.11.2@sha256:7bf02513144c7a157965fb8e9ad5865f5e84fa679afa7cb61fc0a8e140a40070" "$compose" >/dev/null
 grep -Fx "      CKPOOL_IMAGE: ghcr.io/willitmod/5tratsmack-ckpool:0.11.3@${ckpool_digest}" "$compose" >/dev/null
+grep -Fx "      DEV_FUND_ADDRESS: 5trat:qr7rg4z88tc34fr0z0mtkjc0c6s3knw5hce39q9evk" "$compose" >/dev/null
+grep -Fx '      DEV_FEE_PERCENT: "5"' "$compose" >/dev/null
+grep -Fx "      FIVETRAT_DEV_FUND_ADDRESS: 5trat:qr7rg4z88tc34fr0z0mtkjc0c6s3knw5hce39q9evk" "$compose" >/dev/null
 printf 'Prepared MAIN from source %s\napp=%s\nckpool=%s\n' "$source_revision" "$app_digest" "$ckpool_digest"

--- a/scripts/finalize-5tratsmack-0.11.10-main.sh
+++ b/scripts/finalize-5tratsmack-0.11.10-main.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+if [[ "$#" -ne 3 ]]; then
+  echo "usage: $0 SOURCE_REVISION APP_INDEX_DIGEST CKPOOL_INDEX_DIGEST" >&2
+  exit 64
+fi
+
+source_revision="$1"
+app_digest="$2"
+ckpool_digest="$3"
+repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+compose="$repo_root/willitmod-dev-5tratsmack/docker-compose.yml"
+
+[[ "$source_revision" =~ ^[0-9a-f]{40}$ ]]
+[[ "$app_digest" =~ ^sha256:[0-9a-f]{64}$ ]]
+[[ "$ckpool_digest" =~ ^sha256:[0-9a-f]{64}$ ]]
+
+replace_once() {
+  local needle="$1"
+  local replacement="$2"
+  local path="$3"
+  local count tmp line
+  count="$(grep -oF -- "$needle" "$path" | wc -l | tr -d ' ')"
+  if [[ "$count" -lt 1 ]]; then
+    echo "expected at least one $needle placeholder in $path, found $count" >&2
+    exit 1
+  fi
+  tmp="$(mktemp "${path}.finalize.XXXXXX")"
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    printf '%s\n' "${line//$needle/$replacement}"
+  done <"$path" >"$tmp"
+  chmod 0644 "$tmp"
+  mv -f "$tmp" "$path"
+}
+
+replace_once SOURCE_REVISION_REQUIRED "$source_revision" "$compose"
+replace_once APP_INDEX_DIGEST_REQUIRED "$app_digest" "$compose"
+replace_once CKPOOL_INDEX_DIGEST_REQUIRED "$ckpool_digest" "$compose"
+
+if grep -F '_REQUIRED' "$compose"; then
+  echo "unresolved release placeholder remains" >&2
+  exit 1
+fi
+grep -Fx "    image: ghcr.io/willitmod/5tratsmack-app:0.11.10@${app_digest}" "$compose" >/dev/null
+grep -Fx "    image: ghcr.io/willitmod/5tratsmack-ckpool:0.11.3@${ckpool_digest}" "$compose" >/dev/null
+grep -Fx "      APP_IMAGE: ghcr.io/willitmod/5tratsmack-app:0.11.10@${app_digest}" "$compose" >/dev/null
+grep -Fx "      APP_REVISION: ${source_revision}" "$compose" >/dev/null
+grep -Fx "      BCH2_NODE_IMAGE: ghcr.io/willitmod/5tratsmack-core:0.11.2@sha256:7bf02513144c7a157965fb8e9ad5865f5e84fa679afa7cb61fc0a8e140a40070" "$compose" >/dev/null
+grep -Fx "      CKPOOL_IMAGE: ghcr.io/willitmod/5tratsmack-ckpool:0.11.3@${ckpool_digest}" "$compose" >/dev/null
+printf 'Prepared MAIN from source %s\napp=%s\nckpool=%s\n' "$source_revision" "$app_digest" "$ckpool_digest"

--- a/willitmod-dev-5tratsmack/5tratstore-app.yml
+++ b/willitmod-dev-5tratsmack/5tratstore-app.yml
@@ -40,15 +40,16 @@ defaultPassword: ""
 releaseNotes: >-
   Jackpot and reliability update: Pink and Gold bonuses settle to the previous
   block's payout script while the current miner remains output zero; malformed
-  metadata and invalid payouts fail closed. The dashboard now labels last-known
-  fiat values and excludes them from order pricing, shows rejected block
-  candidates, and replays the full retained block history. Restart completion
-  waits for the running pool to acknowledge the exact config, while Stratum
-  readiness detects a stopped listener. Incremental log scans, cached history
-  discovery, atomic state writes and locked updates reduce CPU, I/O and state
-  races. The
-  0.11.9 privacy protections remain in place, and existing wallets, blockchain,
-  pool and trading data are retained.
+  metadata and invalid payouts fail closed. Restores the transparent 0.11.8
+  development contribution, enabled by default at 5%, adjustable or optional,
+  and paid only as a disclosed coinbase output after any prior-winner jackpot.
+  Since 0.11.9 did not retain opt-outs, upgrades return to that 5% default. It
+  never withdraws wallet funds. The dashboard labels last-known fiat values,
+  excludes them from order pricing, shows rejected candidates, and replays full
+  retained history. Exact-config restart acknowledgement, live Stratum checks,
+  cached incremental scans and atomic locked state updates improve reliability
+  and performance. The 0.11.9 private local/global trade separation remains,
+  and existing wallets, blockchain, pool and trading data are retained.
 widgets:
   - id: sync
     type: text-with-progress

--- a/willitmod-dev-5tratsmack/5tratstore-app.yml
+++ b/willitmod-dev-5tratsmack/5tratstore-app.yml
@@ -2,14 +2,14 @@ manifestVersion: 1
 id: willitmod-dev-5tratsmack
 category: altcoin
 name: 5tratSmack
-version: "0.11.9"
+version: "0.11.10"
 tagline: Home-miner 5TRAT node, wallet, solo pool and atomic trade lab
 description: >-
   Install and synchronize a complete 5TRAT node, create or restore an encrypted
   wallet, connect home miners to the bundled solo pool, explore the chain, and
   use the atomic trade lab from one 5tratumOS app.
 
-  This MAIN-channel Release Candidate has completed public-chain, wallet, pool,
+  This MAIN-channel release has completed public-chain, wallet, pool,
   MUX pass-through and trading tests. Back up both the mining wallet and trading
   recovery file before moving funds. The trade book uses the public Komodo DeFi
   Framework network through outbound peer connections; every atomic swap still
@@ -38,13 +38,17 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 releaseNotes: >-
-  Privacy hotfix: Your Private Activity now comes only from this installation's
-  isolated trading wallet, and automatic completed-swap relay publication has
-  been removed. Trade Pulse adds separate Global Trades, My Trades and Compare
-  views with readable execution-order charts. Embedded development-fund and
-  donation payment identities are removed; the pool now refuses to mine until
-  the local node validates its configured payout. Adds a GLEEC Wallet & DEX
-  information tab. Existing wallets, blockchain, pool and trading data are retained.
+  Jackpot and reliability update: Pink and Gold bonuses settle to the previous
+  block's payout script while the current miner remains output zero; malformed
+  metadata and invalid payouts fail closed. The dashboard now labels last-known
+  fiat values and excludes them from order pricing, shows rejected block
+  candidates, and replays the full retained block history. Restart completion
+  waits for the running pool to acknowledge the exact config, while Stratum
+  readiness detects a stopped listener. Incremental log scans, cached history
+  discovery, atomic state writes and locked updates reduce CPU, I/O and state
+  races. The
+  0.11.9 privacy protections remain in place, and existing wallets, blockchain,
+  pool and trading data are retained.
 widgets:
   - id: sync
     type: text-with-progress

--- a/willitmod-dev-5tratsmack/docker-compose.yml
+++ b/willitmod-dev-5tratsmack/docker-compose.yml
@@ -180,6 +180,8 @@ services:
       MAXDIFF: "0"
       NONCE2_LENGTH: "4"
       FIVETRAT_MINING_ACTIVATION_HEIGHT: "1000"
+      DEV_FUND_ADDRESS: 5trat:qr7rg4z88tc34fr0z0mtkjc0c6s3knw5hce39q9evk
+      DEV_FEE_PERCENT: "5"
     volumes:
       - ${APP_DATA_DIR}/data/pool:/data/pool
     ports:
@@ -234,6 +236,7 @@ services:
       FIVETRAT_WALLET_NAME: 5tratsmack
       FIVETRAT_WALLET_TRANSFER_DIR: /data/node/wallet-transfers
       FIVETRAT_WALLET_NODE_TRANSFER_DIR: /data/wallet-transfers
+      FIVETRAT_DEV_FUND_ADDRESS: 5trat:qr7rg4z88tc34fr0z0mtkjc0c6s3knw5hce39q9evk
       FIVETRAT_MINING_ACTIVATION_HEIGHT: "1000"
       FIVETRAT_P2P_STATE_PATH: /data/p2p-state/reachability.json
       FIVETRAT_SWAP_CONTROL_URL: http://node-a:7784

--- a/willitmod-dev-5tratsmack/docker-compose.yml
+++ b/willitmod-dev-5tratsmack/docker-compose.yml
@@ -1,6 +1,6 @@
 version: "3.7"
 
-# Release source revision: SOURCE_REVISION_REQUIRED
+# Release source revision: a992f40e96d47348e6a0afa6bc6b70e5e67cbc18
 
 x-node-environment: &node-environment
   FIVETRAT_NETWORK: main
@@ -158,7 +158,7 @@ services:
       start_period: 30s
 
   ckpool:
-    image: ghcr.io/willitmod/5tratsmack-ckpool:0.11.3@CKPOOL_INDEX_DIGEST_REQUIRED
+    image: ghcr.io/willitmod/5tratsmack-ckpool:0.11.3@sha256:95a1a5f343d579206a0f8bb3c961cafa7500b5d487211a0cfb7b989cf34b895e
     command: ["-k", "-L", "-c", "/data/pool/config/ckpool.conf"]
     restart: unless-stopped
     depends_on:
@@ -197,7 +197,7 @@ services:
       start_period: 90s
 
   app:
-    image: ghcr.io/willitmod/5tratsmack-app:0.11.10@APP_INDEX_DIGEST_REQUIRED
+    image: ghcr.io/willitmod/5tratsmack-app:0.11.10@sha256:77873ff141b17e18dd42e6d5bbdbd5fcd3d1f07047b26772e91718b92f3d1a41
     restart: unless-stopped
     depends_on:
       init_permissions:
@@ -216,10 +216,10 @@ services:
       FIVETRAT_STORE_UPDATE_CHANNEL: main
       FIVETRAT_INSTALL_REVISION: main-store
       FIVETRAT_RELEASE_TAG: 0.11.10
-      APP_IMAGE: ghcr.io/willitmod/5tratsmack-app:0.11.10@APP_INDEX_DIGEST_REQUIRED
-      APP_REVISION: SOURCE_REVISION_REQUIRED
+      APP_IMAGE: ghcr.io/willitmod/5tratsmack-app:0.11.10@sha256:77873ff141b17e18dd42e6d5bbdbd5fcd3d1f07047b26772e91718b92f3d1a41
+      APP_REVISION: a992f40e96d47348e6a0afa6bc6b70e5e67cbc18
       BCH2_NODE_IMAGE: ghcr.io/willitmod/5tratsmack-core:0.11.2@sha256:7bf02513144c7a157965fb8e9ad5865f5e84fa679afa7cb61fc0a8e140a40070
-      CKPOOL_IMAGE: ghcr.io/willitmod/5tratsmack-ckpool:0.11.3@CKPOOL_INDEX_DIGEST_REQUIRED
+      CKPOOL_IMAGE: ghcr.io/willitmod/5tratsmack-ckpool:0.11.3@sha256:95a1a5f343d579206a0f8bb3c961cafa7500b5d487211a0cfb7b989cf34b895e
       FIVETRAT_MUX_IDENTITY_URL: http://172.17.0.1:21222/api/integrations/workers
       FIVETRAT_OS_UPDATE_PROXY_BASE: http://host.docker.internal
       NETWORK_IP: "${NETWORK_IP}"

--- a/willitmod-dev-5tratsmack/docker-compose.yml
+++ b/willitmod-dev-5tratsmack/docker-compose.yml
@@ -1,5 +1,7 @@
 version: "3.7"
 
+# Release source revision: SOURCE_REVISION_REQUIRED
+
 x-node-environment: &node-environment
   FIVETRAT_NETWORK: main
   FIVETRAT_RPC_USER: fivetrat
@@ -21,7 +23,7 @@ services:
       - edge
 
   init_permissions:
-    image: alpine:3.22.1
+    image: alpine:3.22.1@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1
     restart: "no"
     volumes:
       - ${APP_DATA_DIR}/data:/data
@@ -62,7 +64,7 @@ services:
           /data/updater
 
   p2p-helper:
-    image: ghcr.io/willitmod/5tratsmack-upnp:0.11.1
+    image: ghcr.io/willitmod/5tratsmack-upnp:0.11.1@sha256:c85d527b8a12007be2565b200b99dfe46781ddaa773831852414d2cc5ad041d0
     restart: unless-stopped
     user: "1000:1000"
     network_mode: host
@@ -96,7 +98,7 @@ services:
       retries: 12
 
   node-a:
-    image: ghcr.io/willitmod/5tratsmack-core:0.11.2
+    image: ghcr.io/willitmod/5tratsmack-core:0.11.2@sha256:7bf02513144c7a157965fb8e9ad5865f5e84fa679afa7cb61fc0a8e140a40070
     restart: unless-stopped
     stop_grace_period: 2m
     depends_on:
@@ -128,7 +130,7 @@ services:
       start_period: 30s
 
   swap:
-    image: ghcr.io/willitmod/5tratsmack-kdf:0.11.1
+    image: ghcr.io/willitmod/5tratsmack-kdf:0.11.1@sha256:9eff0bfdc330bb997eacbce2b98500a52a084d682aec3644b73e663d54e6606a
     restart: unless-stopped
     network_mode: service:node-a
     depends_on:
@@ -156,7 +158,7 @@ services:
       start_period: 30s
 
   ckpool:
-    image: ghcr.io/willitmod/5tratsmack-ckpool:0.11.2
+    image: ghcr.io/willitmod/5tratsmack-ckpool:0.11.3@CKPOOL_INDEX_DIGEST_REQUIRED
     command: ["-k", "-L", "-c", "/data/pool/config/ckpool.conf"]
     restart: unless-stopped
     depends_on:
@@ -185,9 +187,15 @@ services:
     networks:
       - chain
       - edge
+    healthcheck:
+      test: ["CMD", "/usr/local/bin/5tratsmack-ckpool-healthcheck.sh"]
+      interval: 30s
+      timeout: 12s
+      retries: 3
+      start_period: 90s
 
   app:
-    image: ghcr.io/willitmod/5tratsmack-app:0.11.9
+    image: ghcr.io/willitmod/5tratsmack-app:0.11.10@APP_INDEX_DIGEST_REQUIRED
     restart: unless-stopped
     depends_on:
       init_permissions:
@@ -196,16 +204,20 @@ services:
         condition: service_started
     environment:
       APP_ID: 5tratsmack
-      APP_VERSION: 0.11.9
+      APP_VERSION: 0.11.10
       APP_CHANNEL: MAIN
-      APP_RELEASE_PHASE: RC1
+      APP_RELEASE_PHASE: STABLE
       APP_PLATFORM: 5TRATUMOS
       APP_SELF_RESTART_ENABLED: "0"
       FIVETRAT_UPDATER_ENABLED: "0"
       FIVETRAT_STORE_UPDATE_APP_ID: 5tratsmack
       FIVETRAT_STORE_UPDATE_CHANNEL: main
       FIVETRAT_INSTALL_REVISION: main-store
-      FIVETRAT_RELEASE_TAG: 0.11.9
+      FIVETRAT_RELEASE_TAG: 0.11.10
+      APP_IMAGE: ghcr.io/willitmod/5tratsmack-app:0.11.10@APP_INDEX_DIGEST_REQUIRED
+      APP_REVISION: SOURCE_REVISION_REQUIRED
+      BCH2_NODE_IMAGE: ghcr.io/willitmod/5tratsmack-core:0.11.2@sha256:7bf02513144c7a157965fb8e9ad5865f5e84fa679afa7cb61fc0a8e140a40070
+      CKPOOL_IMAGE: ghcr.io/willitmod/5tratsmack-ckpool:0.11.3@CKPOOL_INDEX_DIGEST_REQUIRED
       FIVETRAT_MUX_IDENTITY_URL: http://172.17.0.1:21222/api/integrations/workers
       FIVETRAT_OS_UPDATE_PROXY_BASE: http://host.docker.internal
       NETWORK_IP: "${NETWORK_IP}"

--- a/willitmod-dev-5tratsmack/umbrel-app.yml
+++ b/willitmod-dev-5tratsmack/umbrel-app.yml
@@ -40,15 +40,16 @@ defaultPassword: ""
 releaseNotes: >-
   Jackpot and reliability update: Pink and Gold bonuses settle to the previous
   block's payout script while the current miner remains output zero; malformed
-  metadata and invalid payouts fail closed. The dashboard now labels last-known
-  fiat values and excludes them from order pricing, shows rejected block
-  candidates, and replays the full retained block history. Restart completion
-  waits for the running pool to acknowledge the exact config, while Stratum
-  readiness detects a stopped listener. Incremental log scans, cached history
-  discovery, atomic state writes and locked updates reduce CPU, I/O and state
-  races. The
-  0.11.9 privacy protections remain in place, and existing wallets, blockchain,
-  pool and trading data are retained.
+  metadata and invalid payouts fail closed. Restores the transparent 0.11.8
+  development contribution, enabled by default at 5%, adjustable or optional,
+  and paid only as a disclosed coinbase output after any prior-winner jackpot.
+  Since 0.11.9 did not retain opt-outs, upgrades return to that 5% default. It
+  never withdraws wallet funds. The dashboard labels last-known fiat values,
+  excludes them from order pricing, shows rejected candidates, and replays full
+  retained history. Exact-config restart acknowledgement, live Stratum checks,
+  cached incremental scans and atomic locked state updates improve reliability
+  and performance. The 0.11.9 private local/global trade separation remains,
+  and existing wallets, blockchain, pool and trading data are retained.
 widgets:
   - id: sync
     type: text-with-progress

--- a/willitmod-dev-5tratsmack/umbrel-app.yml
+++ b/willitmod-dev-5tratsmack/umbrel-app.yml
@@ -2,14 +2,14 @@ manifestVersion: 1
 id: willitmod-dev-5tratsmack
 category: altcoin
 name: 5tratSmack
-version: "0.11.9"
+version: "0.11.10"
 tagline: Home-miner 5TRAT node, wallet, solo pool and atomic trade lab
 description: >-
   Install and synchronize a complete 5TRAT node, create or restore an encrypted
   wallet, connect home miners to the bundled solo pool, explore the chain, and
   use the atomic trade lab from one 5tratumOS app.
 
-  This MAIN-channel Release Candidate has completed public-chain, wallet, pool,
+  This MAIN-channel release has completed public-chain, wallet, pool,
   MUX pass-through and trading tests. Back up both the mining wallet and trading
   recovery file before moving funds. The trade book uses the public Komodo DeFi
   Framework network through outbound peer connections; every atomic swap still
@@ -38,13 +38,17 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 releaseNotes: >-
-  Privacy hotfix: Your Private Activity now comes only from this installation's
-  isolated trading wallet, and automatic completed-swap relay publication has
-  been removed. Trade Pulse adds separate Global Trades, My Trades and Compare
-  views with readable execution-order charts. Embedded development-fund and
-  donation payment identities are removed; the pool now refuses to mine until
-  the local node validates its configured payout. Adds a GLEEC Wallet & DEX
-  information tab. Existing wallets, blockchain, pool and trading data are retained.
+  Jackpot and reliability update: Pink and Gold bonuses settle to the previous
+  block's payout script while the current miner remains output zero; malformed
+  metadata and invalid payouts fail closed. The dashboard now labels last-known
+  fiat values and excludes them from order pricing, shows rejected block
+  candidates, and replays the full retained block history. Restart completion
+  waits for the running pool to acknowledge the exact config, while Stratum
+  readiness detects a stopped listener. Incremental log scans, cached history
+  discovery, atomic state writes and locked updates reduce CPU, I/O and state
+  races. The
+  0.11.9 privacy protections remain in place, and existing wallets, blockchain,
+  pool and trading data are retained.
 widgets:
   - id: sync
     type: text-with-progress


### PR DESCRIPTION
## Summary

- publish 5tratSmack `0.11.10` to the MAIN channel
- pin the app and CKPool to the exact immutable multi-architecture digests qualified on DEV
- restore the disclosed development contribution at the 0.11.8 defaults: enabled, 5%, adjustable 1–50%, explicit opt-out
- retain the 0.11.9 local/private versus validated-global trade separation and separate buy/sell averages
- restore valid delayed Pink/Gold jackpot settlement and add fail-closed payout validation
- keep stale fiat references visible as labelled display-only data
- retain rejected-candidate history and improve restart/readiness, state safety, CPU and I/O behavior

## Release evidence

- private source revision: `a992f40e96d47348e6a0afa6bc6b70e5e67cbc18`
- promotion workflow: https://github.com/WillItMod/5tratSmack-private/actions/runs/33642604151
- public release and corresponding source: https://github.com/WillItMod/5tratSmack/releases/tag/v0.11.10
- app index: `sha256:77873ff141b17e18dd42e6d5bbdbd5fcd3d1f07047b26772e91718b92f3d1a41`
- CKPool index: `sha256:95a1a5f343d579206a0f8bb3c961cafa7500b5d487211a0cfb7b989cf34b895e`
- CKPool source archive: `sha256:7e3a500eb2794e56cfd304a9bb7f2739acd3e096af976702e7afd4fd0e01413b`

The final tags were created from the tested RC2 digests without rebuilding. Both indexes contain native AMD64 and ARM64 runtime manifests plus verified SBOM and SLSA provenance.

## Acceptance

- merged DEV-store recipe installed on `10.10.10.235`
- app, CKPool, node, swap and P2P healthy with zero restarts after the update
- chain synchronized, IBD false, template ready, canonical anchors matched
- wallet remained loaded, encrypted and locked; swap remained ready
- Stratum open with live workers; contribution runtime ACK active at 5%
- 66 accepted historical blocks and four historical rejected candidates retained
- no new submission rejects or severe application/pool log errors
- browser checks passed for GBP value display, clearly labelled stale references, Global/My Trades separation, buy/sell averages and Pool settings
- store Compose validates with the platform proxy stub; all runtime images are digest pinned
