### PR TITLE
Release 5tratSmack 0.11.12 to MAIN

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ own licenses.
 
 ## Current app releases
 
-- **5tratSmack** (`willitmod-dev-5tratsmack`) - `0.11.11`
+- **5tratSmack** (`willitmod-dev-5tratsmack`) - `0.11.12`

--- a/scripts/validate-5tratsmack-metadata.py
+++ b/scripts/validate-5tratsmack-metadata.py
@@ -6,12 +6,12 @@ import re
 REPO_ROOT = Path(__file__).resolve().parents[1]
 APP_DIR = REPO_ROOT / "willitmod-dev-5tratsmack"
 
-EXPECTED_VERSION = "0.11.11"
+EXPECTED_VERSION = "0.11.12"
 EXPECTED_PHASE = "STABLE"
-EXPECTED_SOURCE_REVISION = "bd3aa4dbb0e915c7593e461ebf09546654d49134"
+EXPECTED_SOURCE_REVISION = "72eed58ad52274c6b6bf409260a3fc6deca75f2a"
 EXPECTED_APP_REF = (
-    "ghcr.io/willitmod/5tratsmack-app:0.11.11@"
-    "sha256:329b820a39beed7be4441d3c10ce694d7dedc579b62d494084bfcfe8c7755909"
+    "ghcr.io/willitmod/5tratsmack-app:0.11.12@"
+    "sha256:56887fa21813a2e3dc29a9f386d4c0cbc8053cbdc14d01d6b19cf88c5105d05f"
 )
 EXPECTED_CKPOOL_REF = (
     "ghcr.io/willitmod/5tratsmack-ckpool:0.11.3@"
@@ -126,15 +126,16 @@ for line in required_compose_lines:
         raise SystemExit(f"expected one exact compose line: {line}")
 
 expected_readme_line = (
-    "- **5tratSmack** (`willitmod-dev-5tratsmack`) - `0.11.11`"
+    "- **5tratSmack** (`willitmod-dev-5tratsmack`) - `0.11.12`"
 )
 if readme_text.count(expected_readme_line) != 1:
-    raise SystemExit("README current-version entry is not exactly 0.11.11")
+    raise SystemExit("README current-version entry is not exactly 0.11.12")
 
 for release_note_fragment in (
-    "authenticated DEV catalogue",
-    "never offers a downgrade",
-    "private local/global trade separation",
+    "inactive browser tabs pause background polling",
+    "blockchain is not deleted or reindexed",
+    "Private local/global trade separation",
+    "chosen-currency balance and value labelling",
     "default-on 5% development contribution",
 ):
     if release_note_fragment not in manifest_text:

--- a/willitmod-dev-5tratsmack/5tratstore-app.yml
+++ b/willitmod-dev-5tratsmack/5tratstore-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: willitmod-dev-5tratsmack
 category: altcoin
 name: 5tratSmack
-version: "0.11.11"
+version: "0.11.12"
 tagline: Home-miner 5TRAT node, wallet, solo pool and atomic trade lab
 description: >-
   Install and synchronize a complete 5TRAT node, create or restore an encrypted
@@ -38,15 +38,15 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 releaseNotes: >-
-  Update-channel correctness release: the in-app updater now refreshes and
-  reads the selected 5tratumOS catalogue directly. DEV installations explicitly
-  read the authenticated DEV catalogue instead of version fields selected
-  through the system's default store channel. It rejects wrong-channel or
-  malformed catalogue data, clearly reports installations newer than the
-  catalogue, and never offers a downgrade. The 0.11.10 jackpot, reliability,
-  last-known fiat labelling, private local/global trade separation and
-  transparent default-on 5% development contribution remain unchanged.
-  Existing wallets, blockchain, pool and trading data are retained.
+  Runtime efficiency release: node, pool, trade, chart and Explorer refreshes
+  are paced and coalesced, and inactive browser tabs pause background polling.
+  CKPool share logs and Explorer indexing now advance incrementally with bounded
+  reads and writes, startup warm-up and reorg-safe journal recovery, avoiding
+  repeated history scans and large checkpoint rewrites. Existing app state,
+  wallets, blockchain, pool and trading data persist through the update; the
+  blockchain is not deleted or reindexed. Private local/global trade separation
+  and chosen-currency balance and value labelling remain unchanged, as does the
+  transparent default-on 5% development contribution.
 widgets:
   - id: sync
     type: text-with-progress

--- a/willitmod-dev-5tratsmack/docker-compose.yml
+++ b/willitmod-dev-5tratsmack/docker-compose.yml
@@ -1,6 +1,6 @@
 version: "3.7"
 
-# Release source revision: bd3aa4dbb0e915c7593e461ebf09546654d49134
+# Release source revision: 72eed58ad52274c6b6bf409260a3fc6deca75f2a
 
 x-node-environment: &node-environment
   FIVETRAT_NETWORK: main
@@ -197,7 +197,7 @@ services:
       start_period: 90s
 
   app:
-    image: ghcr.io/willitmod/5tratsmack-app:0.11.11@sha256:329b820a39beed7be4441d3c10ce694d7dedc579b62d494084bfcfe8c7755909
+    image: ghcr.io/willitmod/5tratsmack-app:0.11.12@sha256:56887fa21813a2e3dc29a9f386d4c0cbc8053cbdc14d01d6b19cf88c5105d05f
     restart: unless-stopped
     depends_on:
       init_permissions:
@@ -206,7 +206,7 @@ services:
         condition: service_started
     environment:
       APP_ID: 5tratsmack
-      APP_VERSION: 0.11.11
+      APP_VERSION: 0.11.12
       APP_CHANNEL: MAIN
       APP_RELEASE_PHASE: STABLE
       APP_PLATFORM: 5TRATUMOS
@@ -215,9 +215,9 @@ services:
       FIVETRAT_STORE_UPDATE_APP_ID: 5tratsmack
       FIVETRAT_STORE_UPDATE_CHANNEL: main
       FIVETRAT_INSTALL_REVISION: main-store
-      FIVETRAT_RELEASE_TAG: 0.11.11
-      APP_IMAGE: ghcr.io/willitmod/5tratsmack-app:0.11.11@sha256:329b820a39beed7be4441d3c10ce694d7dedc579b62d494084bfcfe8c7755909
-      APP_REVISION: bd3aa4dbb0e915c7593e461ebf09546654d49134
+      FIVETRAT_RELEASE_TAG: 0.11.12
+      APP_IMAGE: ghcr.io/willitmod/5tratsmack-app:0.11.12@sha256:56887fa21813a2e3dc29a9f386d4c0cbc8053cbdc14d01d6b19cf88c5105d05f
+      APP_REVISION: 72eed58ad52274c6b6bf409260a3fc6deca75f2a
       BCH2_NODE_IMAGE: ghcr.io/willitmod/5tratsmack-core:0.11.2@sha256:7bf02513144c7a157965fb8e9ad5865f5e84fa679afa7cb61fc0a8e140a40070
       CKPOOL_IMAGE: ghcr.io/willitmod/5tratsmack-ckpool:0.11.3@sha256:95a1a5f343d579206a0f8bb3c961cafa7500b5d487211a0cfb7b989cf34b895e
       FIVETRAT_MUX_IDENTITY_URL: http://172.17.0.1:21222/api/integrations/workers

--- a/willitmod-dev-5tratsmack/umbrel-app.yml
+++ b/willitmod-dev-5tratsmack/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: willitmod-dev-5tratsmack
 category: altcoin
 name: 5tratSmack
-version: "0.11.11"
+version: "0.11.12"
 tagline: Home-miner 5TRAT node, wallet, solo pool and atomic trade lab
 description: >-
   Install and synchronize a complete 5TRAT node, create or restore an encrypted
@@ -38,15 +38,15 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 releaseNotes: >-
-  Update-channel correctness release: the in-app updater now refreshes and
-  reads the selected 5tratumOS catalogue directly. DEV installations explicitly
-  read the authenticated DEV catalogue instead of version fields selected
-  through the system's default store channel. It rejects wrong-channel or
-  malformed catalogue data, clearly reports installations newer than the
-  catalogue, and never offers a downgrade. The 0.11.10 jackpot, reliability,
-  last-known fiat labelling, private local/global trade separation and
-  transparent default-on 5% development contribution remain unchanged.
-  Existing wallets, blockchain, pool and trading data are retained.
+  Runtime efficiency release: node, pool, trade, chart and Explorer refreshes
+  are paced and coalesced, and inactive browser tabs pause background polling.
+  CKPool share logs and Explorer indexing now advance incrementally with bounded
+  reads and writes, startup warm-up and reorg-safe journal recovery, avoiding
+  repeated history scans and large checkpoint rewrites. Existing app state,
+  wallets, blockchain, pool and trading data persist through the update; the
+  blockchain is not deleted or reindexed. Private local/global trade separation
+  and chosen-currency balance and value labelling remain unchanged, as does the
+  transparent default-on 5% development contribution.
 widgets:
   - id: sync
     type: text-with-progress


### PR DESCRIPTION
## Summary
- promote the DEV-verified 5tratSmack 0.11.12 app image to the MAIN catalogue
- pace and coalesce runtime polling; pause background browser polling while hidden
- use bounded incremental CKPool share-log and Explorer persistence/indexing work
- retain wallets, blockchain, pool, trading state, privacy behaviour, selected-currency values, and the default-on 5% development contribution
- explicitly require no blockchain deletion or reindex during the update

## Immutable release inputs
- source: `72eed58ad52274c6b6bf409260a3fc6deca75f2a`
- app: `ghcr.io/willitmod/5tratsmack-app:0.11.12@sha256:56887fa21813a2e3dc29a9f386d4c0cbc8053cbdc14d01d6b19cf88c5105d05f`
- CKPool remains unchanged: `ghcr.io/willitmod/5tratsmack-ckpool:0.11.3@sha256:95a1a5f343d579206a0f8bb3c961cafa7500b5d487211a0cfb7b989cf34b895e`
- promotion workflow: `33892371058` (passed)

## Validation
- manifests are byte-identical
- `python3 scripts/validate-5tratsmack-metadata.py`
- current-base `git diff --check`
- YAML parse of both manifests and Compose
- stable registry tag resolves to the tested digest for amd64 and arm64

Prepared for MAIN release review. Do not merge until final approval.