### PR TITLE
Release 5tratSmack 0.11.13 wallet recovery checks to MAIN

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ own licenses.
 ## Current app releases
 
 - **AxeBC2** (`willitmod-dev-bc2`) - `0.1.11`
-- **5tratSmack** (`willitmod-dev-5tratsmack`) - `0.11.12`
+- **5tratSmack** (`willitmod-dev-5tratsmack`) - `0.11.13`

--- a/scripts/validate-5tratsmack-metadata.py
+++ b/scripts/validate-5tratsmack-metadata.py
@@ -6,12 +6,12 @@ import re
 REPO_ROOT = Path(__file__).resolve().parents[1]
 APP_DIR = REPO_ROOT / "willitmod-dev-5tratsmack"
 
-EXPECTED_VERSION = "0.11.12"
+EXPECTED_VERSION = "0.11.13"
 EXPECTED_PHASE = "STABLE"
-EXPECTED_SOURCE_REVISION = "72eed58ad52274c6b6bf409260a3fc6deca75f2a"
+EXPECTED_SOURCE_REVISION = "53f0415e517952a98d21f02b11009976a16a1d20"
 EXPECTED_APP_REF = (
-    "ghcr.io/willitmod/5tratsmack-app:0.11.12@"
-    "sha256:56887fa21813a2e3dc29a9f386d4c0cbc8053cbdc14d01d6b19cf88c5105d05f"
+    "ghcr.io/willitmod/5tratsmack-app:0.11.13@"
+    "sha256:70d007cf7a65fcdbee82d50c70d48aacb63af66b4cd9985e919bd99387401a42"
 )
 EXPECTED_CKPOOL_REF = (
     "ghcr.io/willitmod/5tratsmack-ckpool:0.11.3@"
@@ -126,17 +126,18 @@ for line in required_compose_lines:
         raise SystemExit(f"expected one exact compose line: {line}")
 
 expected_readme_line = (
-    "- **5tratSmack** (`willitmod-dev-5tratsmack`) - `0.11.12`"
+    "- **5tratSmack** (`willitmod-dev-5tratsmack`) - `0.11.13`"
 )
 if readme_text.count(expected_readme_line) != 1:
-    raise SystemExit("README current-version entry is not exactly 0.11.12")
+    raise SystemExit("README current-version entry is not exactly 0.11.13")
 
 for release_note_fragment in (
-    "inactive browser tabs pause background polling",
-    "blockchain is not deleted or reindexed",
-    "Private local/global trade separation",
-    "chosen-currency balance and value labelling",
-    "default-on 5% development contribution",
+    "Quarterly recovery checks",
+    "test your",
+    "Optional unencrypted files require an explicit warning",
+    "downloading alone does not complete a quarterly check",
+    "cryptography dependency is",
+    "only the application image changes.",
 ):
     if release_note_fragment not in manifest_text:
         raise SystemExit(f"release notes missing: {release_note_fragment}")

--- a/willitmod-dev-5tratsmack/5tratstore-app.yml
+++ b/willitmod-dev-5tratsmack/5tratstore-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: willitmod-dev-5tratsmack
 category: altcoin
 name: 5tratSmack
-version: "0.11.12"
+version: "0.11.13"
 tagline: Home-miner 5TRAT node, wallet, solo pool and atomic trade lab
 description: >-
   Install and synchronize a complete 5TRAT node, create or restore an encrypted
@@ -38,15 +38,18 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 releaseNotes: >-
-  Runtime efficiency release: node, pool, trade, chart and Explorer refreshes
-  are paced and coalesced, and inactive browser tabs pause background polling.
-  CKPool share logs and Explorer indexing now advance incrementally with bounded
-  reads and writes, startup warm-up and reorg-safe journal recovery, avoiding
-  repeated history scans and large checkpoint rewrites. Existing app state,
-  wallets, blockchain, pool and trading data persist through the update; the
-  blockchain is not deleted or reindexed. Private local/global trade separation
-  and chosen-currency balance and value labelling remain unchanged, as does the
-  transparent default-on 5% development contribution.
+  Quarterly recovery checks help protect the main and trading wallets: test your
+  saved wallet password, read back a saved recovery file, and download a fresh
+  backup. Encryption with a separate backup passphrase is recommended and selected
+  by default. Optional unencrypted files require an explicit warning because
+  anyone with the file can spend the coins; store them securely offline. Both
+  recovery formats can restore with a new wallet password. Native .dat backups
+  still require their original wallet password. Checks never move funds or replace
+  a wallet, and downloading alone does not complete a quarterly check. A seven-day
+  reminder option is available. Portable recovery now preserves older private keys,
+  full address ranges and indices above 1,000. The cryptography dependency is
+  updated to 50.0.1 and backup download tokens are redacted from logs. Existing
+  wallet, chain, mining and trading data persist; only the application image changes.
 widgets:
   - id: sync
     type: text-with-progress

--- a/willitmod-dev-5tratsmack/docker-compose.yml
+++ b/willitmod-dev-5tratsmack/docker-compose.yml
@@ -1,6 +1,6 @@
 version: "3.7"
 
-# Release source revision: 72eed58ad52274c6b6bf409260a3fc6deca75f2a
+# Release source revision: 53f0415e517952a98d21f02b11009976a16a1d20
 
 x-node-environment: &node-environment
   FIVETRAT_NETWORK: main
@@ -197,7 +197,7 @@ services:
       start_period: 90s
 
   app:
-    image: ghcr.io/willitmod/5tratsmack-app:0.11.12@sha256:56887fa21813a2e3dc29a9f386d4c0cbc8053cbdc14d01d6b19cf88c5105d05f
+    image: ghcr.io/willitmod/5tratsmack-app:0.11.13@sha256:70d007cf7a65fcdbee82d50c70d48aacb63af66b4cd9985e919bd99387401a42
     restart: unless-stopped
     depends_on:
       init_permissions:
@@ -206,7 +206,7 @@ services:
         condition: service_started
     environment:
       APP_ID: 5tratsmack
-      APP_VERSION: 0.11.12
+      APP_VERSION: 0.11.13
       APP_CHANNEL: MAIN
       APP_RELEASE_PHASE: STABLE
       APP_PLATFORM: 5TRATUMOS
@@ -215,9 +215,9 @@ services:
       FIVETRAT_STORE_UPDATE_APP_ID: 5tratsmack
       FIVETRAT_STORE_UPDATE_CHANNEL: main
       FIVETRAT_INSTALL_REVISION: main-store
-      FIVETRAT_RELEASE_TAG: 0.11.12
-      APP_IMAGE: ghcr.io/willitmod/5tratsmack-app:0.11.12@sha256:56887fa21813a2e3dc29a9f386d4c0cbc8053cbdc14d01d6b19cf88c5105d05f
-      APP_REVISION: 72eed58ad52274c6b6bf409260a3fc6deca75f2a
+      FIVETRAT_RELEASE_TAG: 0.11.13
+      APP_IMAGE: ghcr.io/willitmod/5tratsmack-app:0.11.13@sha256:70d007cf7a65fcdbee82d50c70d48aacb63af66b4cd9985e919bd99387401a42
+      APP_REVISION: 53f0415e517952a98d21f02b11009976a16a1d20
       BCH2_NODE_IMAGE: ghcr.io/willitmod/5tratsmack-core:0.11.2@sha256:7bf02513144c7a157965fb8e9ad5865f5e84fa679afa7cb61fc0a8e140a40070
       CKPOOL_IMAGE: ghcr.io/willitmod/5tratsmack-ckpool:0.11.3@sha256:95a1a5f343d579206a0f8bb3c961cafa7500b5d487211a0cfb7b989cf34b895e
       FIVETRAT_MUX_IDENTITY_URL: http://172.17.0.1:21222/api/integrations/workers

--- a/willitmod-dev-5tratsmack/umbrel-app.yml
+++ b/willitmod-dev-5tratsmack/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: willitmod-dev-5tratsmack
 category: altcoin
 name: 5tratSmack
-version: "0.11.12"
+version: "0.11.13"
 tagline: Home-miner 5TRAT node, wallet, solo pool and atomic trade lab
 description: >-
   Install and synchronize a complete 5TRAT node, create or restore an encrypted
@@ -38,15 +38,18 @@ path: ""
 defaultUsername: ""
 defaultPassword: ""
 releaseNotes: >-
-  Runtime efficiency release: node, pool, trade, chart and Explorer refreshes
-  are paced and coalesced, and inactive browser tabs pause background polling.
-  CKPool share logs and Explorer indexing now advance incrementally with bounded
-  reads and writes, startup warm-up and reorg-safe journal recovery, avoiding
-  repeated history scans and large checkpoint rewrites. Existing app state,
-  wallets, blockchain, pool and trading data persist through the update; the
-  blockchain is not deleted or reindexed. Private local/global trade separation
-  and chosen-currency balance and value labelling remain unchanged, as does the
-  transparent default-on 5% development contribution.
+  Quarterly recovery checks help protect the main and trading wallets: test your
+  saved wallet password, read back a saved recovery file, and download a fresh
+  backup. Encryption with a separate backup passphrase is recommended and selected
+  by default. Optional unencrypted files require an explicit warning because
+  anyone with the file can spend the coins; store them securely offline. Both
+  recovery formats can restore with a new wallet password. Native .dat backups
+  still require their original wallet password. Checks never move funds or replace
+  a wallet, and downloading alone does not complete a quarterly check. A seven-day
+  reminder option is available. Portable recovery now preserves older private keys,
+  full address ranges and indices above 1,000. The cryptography dependency is
+  updated to 50.0.1 and backup download tokens are redacted from logs. Existing
+  wallet, chain, mining and trading data persist; only the application image changes.
 widgets:
   - id: sync
     type: text-with-progress


### PR DESCRIPTION
Release quarterly recovery checks for main and trading wallets. Users test a saved password, download a recovery file with an independent encryption passphrase by default or explicitly acknowledge an unencrypted export, and verify a saved backup without importing it. Password and backup checks must both succeed to complete the quarter.

Pin app 0.11.13 to source `53f0415e517952a98d21f02b11009976a16a1d20` and exact tested multi-platform digest `sha256:70d007cf7a65fcdbee82d50c70d48aacb63af66b4cd9985e919bd99387401a42`. Additional fixes preserve older private keys and high address indices in portable recovery, redact backup tokens from logs, and update cryptography to 50.0.1. Non-app image pins and channel identity are preserved.

Validation: private checks, AMD64/ARM64 builds, isolated real Core encrypted/unencrypted restore tests on 10.10.10.235, and MAIN metadata validation passed. Merge after the same digest is promoted to the stable 0.11.13 tag.
